### PR TITLE
change expire in sec to pexpire in ms in python

### DIFF
--- a/clients/redis/python/memorix_client_redis/cache/cache_item.py
+++ b/clients/redis/python/memorix_client_redis/cache/cache_item.py
@@ -41,7 +41,7 @@ class CacheItem(typing.Generic[KT, PT]):
 
         hashed_key = self._key(key=key)
 
-        self._api._connection.redis.expire(
+        self._api._connection.redis.pexpire(
             hashed_key,
             ttl_ms,
         )


### PR DESCRIPTION
In python redis client, you use expire in function of extend, but the ttl is in ms. So you need to use pexpire for ms.